### PR TITLE
move plasmic project id and api key to env

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,13 @@
+### IMPORTANT
+
+### - This `.env` file is tracked by git.
+
+### - Only add default variables to this file
+
+### - Create an `.env.local` to add your own variables.
+
 NEXT_PUBLIC_MGNL_HOST=http://localhost:8080/magnoliaAuthor
 NEXT_PUBLIC_MGNL_LANGUAGES="en de"
 NEXT_PUBLIC_MGNL_NODE_NAME="/nextjs-ssg-minimal"
+PLASMIC_PROJECT_ID="9fuL7F7jJuiHG9rz5yy9QV"
+PLASMIC_API_TOKEN="83UCv8jjhkcp6sui879G9obrMzKoV2ubB4WRAXFsJXD4XM9m6ee0rvjCQJupGtyuCtVoDDkMom3tTNT8MqlEQ"

--- a/plasmic-init.ts
+++ b/plasmic-init.ts
@@ -14,8 +14,9 @@ import {
 export const PLASMIC = initPlasmicLoader({
   projects: [
     {
-      id: "9fuL7F7jJuiHG9rz5yy9QV",
-      token: "83UCv8jjhkcp6sui879G9obrMzKoV2ubB4WRAXFsJXD4XM9m6ee0rvjCQJupGtyuCtVoDDkMom3tTNT8MqlEQ",
+      id: process.env.PLASMIC_PROJECT_ID ?? "",
+      
+      token: process.env.PLASMIC_API_TOKEN ?? "" ,
     },
   ],
 

--- a/plasmic-init.ts
+++ b/plasmic-init.ts
@@ -15,7 +15,6 @@ export const PLASMIC = initPlasmicLoader({
   projects: [
     {
       id: process.env.PLASMIC_PROJECT_ID ?? "",
-      
       token: process.env.PLASMIC_API_TOKEN ?? "" ,
     },
   ],


### PR DESCRIPTION
Moved the existing plasmic id and key into the env file as the default project and used the language from canario to help identify environment variables that need to be updated when developing in a different workspace.

Obviously we shouldn't be exposing these keys in the repo but since it was already committed I figured it was "safe" to move it to an env, but probably best if we remove it and request a new api token and then follow best practices to keep it out of the codebase